### PR TITLE
travis: Use `./gradlew check` instead of `./gradlew test` for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 script:
-  - ./gradlew test
+  - ./gradlew check


### PR DESCRIPTION
Because `./gradlew check` invokes `checkstyle` and `findbugs` in
before testing.
`./gradlew test` invokes only test task.
We can find out more issues than using `./gradle test`.
