### PR TITLE
Due to EOL, drop Java 7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ configurations {
 
 version = "0.3.0"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compile  "org.embulk:embulk-core:0.9.7"


### PR DESCRIPTION
@takumakanari PTAL
Embulk 0.9 require Java 8.
