### PR TITLE
Fix deprecated warning in build.gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,11 @@ task gemPush(type: JRubyExec, dependsOn: ["gem"]) {
     script "pkg/${project.name}-${project.version}.gem"
 }
 
-task "package"(dependsOn: ["gemspec", "classpath"]) << {
-    println "> Build succeeded."
-    println "> You can run embulk with '-L ${file(".").absolutePath}' argument."
+task "package"(dependsOn: ["gemspec", "classpath"]) {
+    doLast {
+        println "> Build succeeded."
+        println "> You can run embulk with '-L ${file(".").absolutePath}' argument."
+    }
 }
 
 task gemspec {


### PR DESCRIPTION
@takumakanari This PR is the last at this time.

Fix the following deprecated warning.

```
> Configure project :
The Task.leftShift(Closure) method has been deprecated and
is scheduled to be removed in Gradle 5.0.
Please use Task.doLast(Action) instead.
```